### PR TITLE
[DEVEX-300] Switch to Maven Publish

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.1'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/indicator-fast-scroll/build.gradle
+++ b/indicator-fast-scroll/build.gradle
@@ -1,17 +1,8 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'com.novoda.bintray-release'
+apply plugin: 'maven-publish'
 
-buildscript {
-    repositories {
-        jcenter()
-    }
-    dependencies {
-        classpath 'com.novoda:bintray-release:0.9.2'
-    }
-}
-
-def libraryVersionName = '1.4.0'
+def libraryVersionName = '1.4.0-favor'
 
 android {
     compileSdkVersion 29
@@ -34,16 +25,25 @@ android {
     }
 }
 
-publish {
-    userOrg = 'reddit'
-    groupId = 'com.reddit'
-    repoName = 'IndicatorFastScroll'
-    artifactId = 'indicator-fast-scroll'
-    publishVersion = libraryVersionName
-    desc = ''
-    website = ''
-    autoPublish = false
-    dryRun = false
+afterEvaluate {
+    publishing {
+        publications {
+            IndicatorFastScroll(MavenPublication) {
+                from components.release
+                groupId 'com.reddit'
+                artifactId 'indicator-fast-scroll'
+                version '1.4.0-favor'
+            }
+        }
+
+        repositories {
+            maven {
+                name = "IndicatorFastScrollRepo"
+                url = project.uri("https://maven.pkg.github.com/favordelivery/IndicatorFastScroll")
+                credentials(PasswordCredentials)
+            }
+        }
+    }
 }
 
 dependencies {

--- a/readme.md
+++ b/readme.md
@@ -3,6 +3,18 @@
 # Indicator Fast Scroll
 ###### by reddit
 
+## Publishing
+
+This repo does not support automated publishing. The version must be updated in the build.gradle file under
+`publications`. In addition, the global gradle.properties file must contain two new properties:
+```
+IndicatorFastScrollRepoUsername=favordelivery
+IndicatorFastScrollRepoPassword=<token_here>
+```
+Once those are in place, then running the command 
+`publishIndicatorFastScrollPublicationToIndicatorFastScrollRepoRepository` will publish the package to the internal
+copy of this repo.
+
 ## Features
 
 * Simple interface for expressing your data via fast scroll indicators
@@ -17,7 +29,7 @@
 Add the dependency to your app's `build.gradle`:
 ##### AndroidX:
 ```groovy
-implementation 'com.reddit:indicator-fast-scroll:1.4.0'
+implementation 'com.reddit:indicator-fast-scroll:1.4.0-favor'
 ```
 ##### Pre-AndroidX (older projects):
 ```groovy


### PR DESCRIPTION
Ticket
------------------------------------------------------------------------
[DEVEX-300]

Context
------------------------------------------------------------------------
This change replaces the current publishing mechanism in the forked
version of the IndicatorFastScroll codebase so that developers can
publish to our internal Favor Delivery packages.

Changes
------------------------------------------------------------------------
* Updated Gradle Wrapper.
* Updated AGP.
* Switched out publishing mechanism.

[DEVEX-300]: https://favorengineering.atlassian.net/browse/DEVEX-300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ